### PR TITLE
ghw: fix release-action version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: setup golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         id: go
         with:
           go-version: 1.20


### PR DESCRIPTION
using go 1.20 requires v3 of the release action.