### PR TITLE
add memory resources alignment check

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/shajmakh/numaalign-rewritten/internal"
 	. "github.com/shajmakh/numaalign-rewritten/internal/cpu"
 	. "github.com/shajmakh/numaalign-rewritten/internal/device"
+	. "github.com/shajmakh/numaalign-rewritten/internal/memory"
 
 	"github.com/shajmakh/numaalign-rewritten/pkg/numa"
 )
@@ -75,6 +76,8 @@ func main() {
 	CheckCpuAlignment(processId, &output)
 
 	CheckPciDevicesAlignment(&output)
+
+	CheckMemoryResourcesAlignment(processId, &output)
 
 	LogNumaAlignment(output)
 

--- a/internal/helper.go
+++ b/internal/helper.go
@@ -31,7 +31,7 @@ var (
 
 // LogNumaAlignment prints the final result of the program, -1 if resources are not aligned,otherwise the numa on which all the resources are aligned
 func LogNumaAlignment(res NumaAlignmentOutput) {
-	WriteToDest(fmt.Sprintf("NUMA: %d\n", res.NNode))
+	WriteToDest(fmt.Sprintf("Is Aligned: %t\nNUMA: %d\n", res.IsAligned, res.NNode))
 
 	if Verbose {
 		printResources(res.ProccessResources)
@@ -42,7 +42,7 @@ func LogNumaAlignment(res NumaAlignmentOutput) {
 }
 
 func printResources(rsrc ProccessResources) { //could be done a ToString() instead but would it be worth it to have another file for the process details (=app output)?
-	WriteToDest(fmt.Sprintf("consumed resources:\n CPUs:\n%v\n PCI devices:\n%v\n Memory:\n%v\n", rsrc.CPUs.String(), rsrc.PCI, rsrc.Memory))
+	WriteToDest(fmt.Sprintf("consumed resources:\n CPUs:\n%v\n PCI devices:\n%v\n Memory:\n%s\n", rsrc.CPUs.String(), rsrc.PCI, rsrc.Memory))
 }
 
 func WriteToDest(str string) {

--- a/internal/helper.go
+++ b/internal/helper.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"regexp"
 )
 
 var (
@@ -56,4 +57,16 @@ func NewOutput() NumaAlignmentOutput {
 	o.NNode = -1
 	o.IsAligned = true
 	return *o
+}
+
+/*
+GetValue returns slice of strings that matches the value after the passed key.
+The expected syntax should be "key:value", otherwise it'll return nil slice.
+In a successful matching case, the strings slice contains the first elemant as "from"
+and subsequent elements are the matching strings to the compiled pattern
+*/
+func GetValue(key string, from string) []string {
+	re := regexp.MustCompile(fmt.Sprintf(`%s:(.*)`, key))
+	match := re.FindStringSubmatch(from)
+	return match
 }

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -48,15 +48,19 @@ func CheckMemoryResourcesAlignment(pid string, output *NumaAlignmentOutput) {
 		output.Err = fmt.Errorf("value %s not found in %s", MEMS_ALLOWED_LIST, outStr)
 		return
 	}
-	checkAlignmentWith(match[1], output)
+	CheckAlignmentWith(match[1], output)
 }
 
-func checkAlignmentWith(memStr string, output *NumaAlignmentOutput) {
+func CheckAlignmentWith(memStr string, output *NumaAlignmentOutput) {
+	if !output.IsAligned {
+		return
+	}
 	//the memory nodes value is similarly presented as CPUset so it can be parsed as cpuset
 	val := strings.TrimSpace(memStr)
 	nodeList, err := cpuset.Parse(val)
 	if err != nil {
 		output.IsAligned = false
+		output.NNode = -1
 		output.Err = fmt.Errorf("could not parse memory nodes' list: %v", err)
 		return
 	}
@@ -64,6 +68,7 @@ func checkAlignmentWith(memStr string, output *NumaAlignmentOutput) {
 	output.ProccessResources.Memory = val
 	if nodeList.Size() > 1 {
 		output.IsAligned = false
+		output.NNode = -1
 		return
 	}
 

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -1,0 +1,77 @@
+/*
+ *Copyright 2023 Red Hat, Inc.
+ *
+ *Licensed under the Apache License, Version 2.0 (the "License");
+ *you may not use this file except in compliance with the License.
+ *You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing, software
+ *distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *See the License for the specific language governing permissions and
+ *limitations under the License.
+ */
+
+package memory
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	. "github.com/shajmakh/numaalign-rewritten/internal"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+)
+
+const MEMS_ALLOWED_LIST = "Mems_allowed_list"
+
+func CheckMemoryResourcesAlignment(pid string, output *NumaAlignmentOutput) {
+	if !output.IsAligned {
+		return
+	}
+
+	out, err := exec.Command("cat", fmt.Sprintf("/proc/%s/status", pid)).Output()
+	if err != nil {
+		output.IsAligned = false
+		output.Err = err
+		return
+	}
+
+	outStr := string(out[:])
+
+	match := GetValue(MEMS_ALLOWED_LIST, outStr)
+	if len(match) == 0 {
+		output.IsAligned = false
+		output.Err = fmt.Errorf("value %s not found in %s", MEMS_ALLOWED_LIST, outStr)
+		return
+	}
+	checkAlignmentWith(match[1], output)
+}
+
+func checkAlignmentWith(memStr string, output *NumaAlignmentOutput) {
+	//the memory nodes value is similarly presented as CPUset so it can be parsed as cpuset
+	val := strings.TrimSpace(memStr)
+	nodeList, err := cpuset.Parse(val)
+	if err != nil {
+		output.IsAligned = false
+		output.Err = fmt.Errorf("could not parse memory nodes' list: %v", err)
+		return
+	}
+
+	output.ProccessResources.Memory = val
+	if nodeList.Size() > 1 {
+		output.IsAligned = false
+		return
+	}
+
+	node, _ := strconv.Atoi(val)
+	if node != output.NNode && output.NNode != -1 {
+		output.IsAligned = false
+		output.NNode = -1
+		return
+	}
+	output.NNode = node
+}

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -1,0 +1,40 @@
+package memory
+
+import (
+	"testing"
+
+	. "github.com/shajmakh/numaalign-rewritten/internal"
+)
+
+func TestCheckAlignmentWith(t *testing.T) {
+	testCases := []struct {
+		memoryNodeString  string
+		expectedNuma      int
+		expectedIsAligned bool
+	}{
+		{
+			"0",
+			0,
+			true,
+		},
+		{
+			"   0-3,5 ",
+			-1,
+			false,
+		},
+		{
+			"0-1",
+			-1,
+			false,
+		},
+	}
+
+	for _, c := range testCases {
+		out := NewOutput()
+		CheckAlignmentWith(c.memoryNodeString, &out)
+		if out.NNode != c.expectedNuma || out.IsAligned != c.expectedIsAligned {
+			t.Fatalf("expected alignment: %t:%d ; actual: %t/%d ; memory nodes:[%s]", c.expectedIsAligned, c.expectedNuma, out.IsAligned, out.NNode, c.memoryNodeString)
+		}
+	}
+
+}

--- a/internal/types.go
+++ b/internal/types.go
@@ -28,5 +28,5 @@ type NumaAlignmentOutput struct {
 type ProccessResources struct {
 	CPUs   cpuset.CPUSet
 	PCI    []string
-	Memory []string
+	Memory string
 }


### PR DESCRIPTION
Till now, the app only supported checking numa alignment of cpus and pci devices of a proccess, while memory resources check was missing.

Add alignment check for memory resources of the process by checking cpuset.mem of cgroup that is reflected as Mems_allowed_list under /proc/pid/status.

While doing so, adjust the affected variables to match the result of the memory values.
